### PR TITLE
fix: corrigir margins e paddins da primeira seção

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,24 +14,24 @@ export default function Home() {
   return (
     <main className="overflow-hidden">
       <div id="first-section">
-        <div className="h-[92vh] bg-customRed relative
+        <div className="h-[90vh] bg-customRed relative
         md:flex md:flex-row-reverse">
           <div className="md:w-[50vw] md:flex md:flex-col-reverse md:items-end">
             <div className="bg-customWhite h-28 w-full absolute top-0 z-0
             md:w-[50%] md:relative md:h-[11vh]">
             </div>
-            <div className="flex justify-center h-[45vh]
+            <div className="flex justify-center h-[40vh]
             md:h-[85vh] md:w-full">
               <Image src="/assets/Rodrigo-pastor-alemão.png" alt='foto do Rodrigo adestrando um pastor alemão' width={1000} height={1000} className='object-cover object-bottom rounded-b-3xl z-10 h-full w-[85%]
               md:w-full md:rounded-br-none' />
             </div>
           </div>
-          <div className="flex flex-col items-center justify-evenly h-[51vh]
+          <div className="flex flex-col items-center justify-evenly h-[50vh]
           md:items-start md:justify-between md:w-[50vw] md:h-[96vh] md:pt-4">
             {/* versão mobile */}
-            <div className="md:hidden mt-[-15px] h-md:mt-[-25px] h-lg:mt-[-55px]">
+            <div className="md:hidden mt-[-15px] h-md:mt-[-25px] h-lg:mt-[-35px] h-md:py-4 h-lg:pb-6 h-lg:pt-4">
               <LineTitle lineType='white' className='w-full'>
-                <Image src='/assets/top-caes-logo-(letra-branca).png' alt='logo da TopCães' width={1000} height={1000} className='min-w-[140px] h-md:min-w-[175px] h-lg:min-w-[185px]' />
+                <Image src='/assets/top-caes-logo-(letra-branca).png' alt='logo da TopCães' width={1000} height={1000} className='min-w-[140px] h-md:min-w-[175px] h-lg:min-w-[220px]' />
               </LineTitle>
             </div>
             {/* versão tablet/desktop */}
@@ -46,7 +46,7 @@ export default function Home() {
             </div>
             <div className="flex flex-col items-center gap-12
             md:gap-0  md:pb-20 md:justify-evenly md:h-full">
-              <h1 className="text-center text-4xl uppercase font-extrabold text-customWhite px-3 h-md:text-[30px] h-md:leading-8 h-md:pb-0 h-md:mt-[-18px] h-lg:mt-[-48px] h-lg:text-4xl
+              <h1 className="text-center text-4xl uppercase font-extrabold text-customWhite px-3  h-md:pb-0 h-md:mt-[-18px]
               md:text-6xl md:w-full
               2xl:text-7xl
               3xl:text-9xl">seu <span className="text-customBlack">cão</span> também merece <span className="text-customBlack">educação</span>!</h1>


### PR DESCRIPTION
# Changelog 📝

- Corrige o espaçamento entre logo, texto e botão em todas as versões mobile (margins e paddins)
- Corrige tamanho da logo em todas as versões mobile